### PR TITLE
グループ・ユーザに関するモックの修正と新規作成

### DIFF
--- a/app/views/groups/edit.html.slim
+++ b/app/views/groups/edit.html.slim
@@ -4,32 +4,35 @@
 br
 
 .row
-    form.form-horizontal role ="form"
-        .form-group
-            label.col-sm-2 align="right" for="InputIconImage" アイコン
-            .col-sm-8
-                input#InputIconImage type="file"
-                .help-block 推奨サイズは140×140です。
+  form.form-horizontal role ="form"
+    .form-group
+      label.col-sm-2 align="right" for="InputIconImage" アイコン
+      .col-sm-8
+        input#InputIconImage type="file"
+        .help-block 推奨サイズは140×140です。
 
-        .form-group.form-group-lg
-            label.col-sm-2.control-label for="InputGroupName" グループ名
-            .col-sm-8
-                input#InputGroupName type="text" class="form-control"
+    .form-group.form-group-lg
+      label.col-sm-2.control-label for="InputGroupName" グループ名
+      .col-sm-8
+        input#InputGroupName type="text" class="form-control"
 
-        .form-group.form-group-lg
-            label.col-sm-2.control-label for="InputIntroduction" 概要
-            .col-sm-8
-                textarea#InputIntroduction class="form-control" rows="3"
+    .form-group.form-group-lg
+      label.col-sm-2.control-label for="InputIntroduction" 概要
+      .col-sm-8
+        textarea#InputIntroduction class="form-control" rows="3"
 
-        .form-group.form-group-lg
-            label.col-sm-2.control-label for="InputMemberName" メンバー1
-            .col-sm-8
-                input#InputMemberName type="text" class="form-control"
+    .form-group.form-group-lg
+      label.col-sm-2.control-label for="InputMemberName" メンバー1
+      .col-sm-8
+        input#InputMemberName type="text" class="form-control"
 
-        .col-sm-2
-            div align="right"
-                button.btn.btn-default type="button" +メンバー追加
-br
-div align="center"
-        button.btn.btn-primary type="button" onclick="location.href='/../../groups/'" 完了
+    .col-sm-2
+      div align="right"
+        button.btn.btn-default type="button"
+          .glyphicon.glyphicon-plus メンバー追加
+    br
+    .col-sm-8
+      br
+      div align="center"
+        button.btn.btn-primary type="submit" 完了
 

--- a/app/views/groups/index.html.slim
+++ b/app/views/groups/index.html.slim
@@ -1,65 +1,65 @@
 .row
-    .col-sm-2
-    .col-sm-8
-        .alert.alert-info role="alert"
-            table border="0"
-                tbody
-                    tr 
-                        td 
-                            .h4 あなたが所属するグループです。 
-                        td
-                            button.btn.btn-warning type="button" onclick="location.href='../groups/1/edit'" 編集
+  .col-sm-2
+  .col-sm-8
+    .alert.alert-info role="alert"
+      table border="0"
+        tbody
+          tr 
+            td 
+              .h4 あなたが所属するグループです。 
+            td
+              button.btn.btn-warning type="button" onclick="location.href='../groups/1/edit'" 編集
 
 br  
-    .col-sm-2
-    .col-sm-4
+  .col-sm-2
+  .col-sm-4
+    table border="0"
+      thead
+      tbody
+        tr
+          img.img-thumbnail width="140" height="140" src="..." alt="..."
+        tr
+          .h2 Group-Name
+    br
+    .panel.panel-success
+      .panel-heading
+        .h4.panel-title 作成したゲーム
+      .panel-body
         table border="0"
-            thead
-            tbody
-                tr
-                    img.img-thumbnail width="140" height="140" src="..." alt="..."
-                tr
-                    .h2 Group-Name
+          tr
+            td
+              img.img-rounded width="50" height="50" src="..." alt="..."
+            td
+              a href="#" オフトゥン・クエスト
+          tr
+            td
+              img.img-rounded width="50" height="50" src="..." alt="..."
+            td
+              a href="#" THE KUSONEMI M@STER
+  table.col-sm-4 border="0" 
+    tr
+      td colspan="2"
+        .h4 概要
+    tr
+      td colspan="2"
+        pre このグループは、SAOを開発するために作られた。
+            開発期間は１年であり、期間延長は原則認めないものとする。
+            開発環境として、ナーヴギアを用いる。
+            被験者は開発者自身とする。
+    tr
+      td
         br
-        .panel.panel-success
-            .panel-heading
-                .h4.panel-title 作成したゲーム
-            .panel-body
-                table border="0"
-                    tr
-                        td
-                            img.img-rounded width="50" height="50" src="..." alt="..."
-                        td
-                            a href="#" オフトゥン・クエスト
-                    tr
-                        td
-                            img.img-rounded width="50" height="50" src="..." alt="..."
-                        td
-                            a href="#" THE KUSONEMI M@STER
-    table.col-sm-4 border="0" 
-        tr
-            td colspan="2"
-                    .h4 概要
-        tr
-            td colspan="2"
-                pre このグループは、SAOを開発するために作られた。
-                    開発期間は１年であり、期間延長は原則認めないものとする。
-                    開発環境として、ナーヴギアを用いる。
-                    被験者は開発者自身とする。
-            tr
-                td
-                    br
-            tr
-                td colspan="2"
-                    .h4 メンバー
-            tr
-                td width="60"
-                    img.img-rounded width="50" height="50" src="..." alt="..."
-                td
-                    a href="../users" Member-A
-            tr
-                td width="60"
-                    img.img-rounded width="50" height="50" src="..." alt="..."
-                td
-                    a href="../users" Member-B
+    tr
+      td colspan="2"
+        .h4 メンバー
+    tr
+      td width="60"
+        img.img-rounded width="50" height="50" src="..." alt="..."
+      td
+        a href="../users" Member-A
+    tr
+      td width="60"
+        img.img-rounded width="50" height="50" src="..." alt="..."
+      td
+        a href="../users" Member-B
 

--- a/app/views/groups/new.html.slim
+++ b/app/views/groups/new.html.slim
@@ -3,31 +3,34 @@
 br
 
 .row
-    form.form-horizontal role ="form"
-        .form-group
-            label.col-sm-2 align="right" for="InputIconImage" アイコン
-            .col-sm-8
-                input#InputIconImage type="file"
-                .help-block 推奨サイズは140×140です。
+  form.form-horizontal role ="form"
+    .form-group
+      label.col-sm-2 align="right" for="InputIconImage" アイコン
+      .col-sm-8
+        input#InputIconImage type="file"
+        .help-block 推奨サイズは140×140です。
 
-        .form-group.form-group-lg
-            label.col-sm-2.control-label for="InputGroupName" グループ名
-            .col-sm-8
-                input#InputGroupName type="text" class="form-control"
+    .form-group.form-group-lg
+      label.col-sm-2.control-label for="InputGroupName" グループ名
+      .col-sm-8
+        input#InputGroupName type="text" class="form-control"
 
-        .form-group.form-group-lg
-            label.col-sm-2.control-label for="InputIntroduction" 概要
-            .col-sm-8
-                textarea#InputIntroduction class="form-control" rows="3"
+    .form-group.form-group-lg
+      label.col-sm-2.control-label for="InputIntroduction" 概要
+      .col-sm-8
+        textarea#InputIntroduction class="form-control" rows="3"
 
-        .form-group.form-group-lg
-            label.col-sm-2.control-label for="InputMemberName" メンバー1
-            .col-sm-8
-                input#InputMemberName type="text" class="form-control"
+    .form-group.form-group-lg
+      label.col-sm-2.control-label for="InputMemberName" メンバー1
+      .col-sm-8
+        input#InputMemberName type="text" class="form-control"
 
-        .col-sm-2
-            div align="right"
-                button.btn.btn-default type="button" +メンバー追加
-br
-div align="center"
-        button.btn.btn-primary type="button" onclick="location.href='../groups'" 完了
+    .col-sm-2
+      div align="right"
+        button.btn.btn-default type="button"
+          .glyphicon.glyphicon-plus メンバー追加
+    br
+    .col-sm-8
+      br
+      div align="center"
+        button.btn.btn-primary type="submit" 完了

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -3,31 +3,31 @@ h1 ユーザ設定
 br
 
 form.form-horizontal role="form"
-    .form-group
-        label.col-sm-2 align="right" for="InputIconImage" アイコン
-        .col-sm-8
-            input#InputIconImage type="file"
-            .help-block 推奨サイズは140×140です。
+  .form-group
+    label.col-sm-2 align="right" for="InputIconImage" アイコン
+    .col-sm-8
+      input#InputIconImage type="file"
+      .help-block 推奨サイズは140×140です。
 
-    .form-group.form-group-lg
-        label.col-sm-2.control-label align="right" for="InputAccountName" アカウント名
-        .col-sm-8
-             input#InputAccountName type="text" class="form-control"
+  .form-group.form-group-lg
+    label.col-sm-2.control-label align="right" for="InputAccountName" アカウント名
+    .col-sm-8
+      input#InputAccountName type="text" class="form-control"
 
-    .form-group.form-group-lg
-        label.col-sm-2.control-label align="right" for="InputUserName" ユーザ名
-        .col-sm-8
-            input#InputUserName type="text" class="form-control"
+  .form-group.form-group-lg
+    label.col-sm-2.control-label align="right" for="InputUserName" ユーザ名
+    .col-sm-8
+      input#InputUserName type="text" class="form-control"
 
-    .form-group.form-group-lg
-        label.col-sm-2.control-label align="right" for="InputPassword" パスワード
-        .col-sm-8
-            input#InputPassword type="password" class="form-control"
+  .form-group.form-group-lg
+    label.col-sm-2.control-label align="right" for="InputPassword" パスワード
+    .col-sm-8
+      input#InputPassword type="password" class="form-control"
 
-    .form-group.form-group-lg
-        label.col-sm-2.control-label align="right" for="ConfirmPassword" パスワード(確認用) 
-        .col-sm-8
-            input#ConfirmPassword type="password" class="form-control"
+  .form-group.form-group-lg
+    label.col-sm-2.control-label align="right" for="ConfirmPassword" パスワード(確認用) 
+    .col-sm-8
+      input#ConfirmPassword type="password" class="form-control"
 
-div align="center"
-    button.btn.btn-primary type="button" onclick="location.href='/../../users'" 完了
+  div align="center"
+    button.btn.btn-primary type="submit" 完了

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -1,28 +1,28 @@
 .row
-    .col-sm-2
-    .col-sm-8
-        table border="0" width="600"
-            tr
-                td width="170"
-                    img.img-thumbnail width="140" height="140" src="..." alt="..."
-                td
-                    p.h1 Name
+  .col-sm-2
+  .col-sm-8
+    table border="0" width="600"
+      tr
+        td width="170"
+          img.img-thumbnail width="140" height="140" src="..." alt="..."
+        td
+          p.h1 Name
 
 br    
-    .col-sm-2
-    .col-sm-8
-        table.table
-            thead
-                th colspan="2"
-                    h3 所属グループ
-            tbody
-                tr
-                    td  width="50"
-                        img.img-rounded width="50" height="50" src="..." alt="..."
-                    td
-                        a href="groups" Group-A
-                tr
-                    td  width="50"
-                        img.img-rounded width="50" height="50" src="..." alt="..."
-                    td
-                        a href="groups" Group-B
+  .col-sm-2
+  .col-sm-8
+    table.table
+      thead
+        th colspan="2"
+          h3 所属グループ
+      tbody
+        tr
+          td  width="50"
+            img.img-rounded width="50" height="50" src="..." alt="..."
+          td
+            a href="groups" Group-A
+        tr
+          td  width="50"
+            img.img-rounded width="50" height="50" src="..." alt="..."
+          td
+            a href="groups" Group-B


### PR DESCRIPTION
- ユーザ設定ページとグループ編集ページを作成
- インデントの幅を2に変更
- ユーザページ
  - 編集ボタンの削除
  - 画像にサイズ指定を追加
  - 名前の位置を左寄りに変更
  - グループページにリンクを繋げる
- グループページ
  - 編集ボタンの色をwarning(黄)に変更
  - 編集ボタンを押すとグループ編集ページに飛ぶように設定
  - 概要とメンバーの位置を右側に変更
  - メンバー名の位置をアイコンの下に変更
  - 画像にサイズ指定を追加
  - 一番上、「あなたが所属~」をアラートに変更
  - 一部の文字の大きさをh4に拡大
  - 作成したゲームをパネルでくくる
  - 全体の位置を中央寄せに変更
- グループ作成ページ
  - 概要にラベルを作成
  - アイコン画像のフォームを一番上に移動
  - メンバーの入力フォーム追加ボタンを作成
  - 完了ボタンの色をprimary(青)に変更
  - 完了ボタンを押すとグループページに飛ぶように設定
  - form.form-horizontal部分を最上位に１つ置き、他を削除
  - +ボタンをラベルの下に移動
  - +ボタンに説明を付属
  - +ボタンをglyphiconに変更
  - plassholderを削除
  - 完了ボタンの属性をsubmitに変更
- グループ編集ページ
  - form.form-horizontal部分を最上位に１つ置き、他を削除
  - +ボタンをラベルの下に移動
  - +ボタンに説明を付属
  - +ボタンをglyphiconに変更
  - plassholderを削除
  - 完了ボタンの属性をsubmitに変更
- ユーザ設定ページ
  - form.form-horizontal部分を最上位に１つ置き、他を削除
  - plassholderを削除
  - 完了ボタンの属性をsubmitに変更
